### PR TITLE
緯度経度からどこの国かをチェックしてからその国のタイルを取得するように修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Geolonia which develop this package does not collect any privacy information bec
 
 また、GitHub ページ上にホストしたベクトルタイルを使用して都道府県名と市区町村を取得するという仕様のため、このモジュールを開発する Geolonia では個人情報の収集を一切行っておらず、安心してご利用ただけます。
 
-## Structure / 組み
+## Structure / 仕組み
 
 1. get the tile number equivalent to zoom level 10 (about 30 km square) on the client side based on the latitude and longitude specified as arguments of `openReverseGeocoder()`, and download the vector tiles from the web server with AJAX.
 2. retrieves the polygons with the specified latitude and longitude from the polygons of cities contained in the vector tiles downloaded by AJAX on the client side, and returns the name of the prefecture and the name of the city.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,11 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@mapbox/vector-tile": "^1.3.1",
         "axios": "^0.21.1",
         "axios-cache-adapter": "^2.7.3",
         "d3-geo": "^2.0.1",
         "global-mercator": "^3.1.0",
-        "pbf": "^3.2.1"
+        "mapbox-vector-tile": "^0.3.0"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^18.0.0",
@@ -22,6 +21,7 @@
         "@rollup/plugin-typescript": "^8.2.1",
         "@tsconfig/node14": "^1.0.0",
         "@types/d3-geo": "^2.0.0",
+        "@types/geojson": "^7946.0.8",
         "@types/jest": "^26.0.20",
         "@types/node": "^14.14.37",
         "@types/pbf": "^3.0.2",
@@ -860,19 +860,6 @@
         "node": ">= 10.14.2"
       }
     },
-    "node_modules/@mapbox/point-geometry": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
-      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI="
-    },
-    "node_modules/@mapbox/vector-tile": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
-      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
-      "dependencies": {
-        "@mapbox/point-geometry": "~0.1.0"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
@@ -907,6 +894,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@protobuf-ts/runtime": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-1.0.13.tgz",
+      "integrity": "sha512-uvYYBUtG4eCYMxo+mzxN8SHvpL/l7PbHEmOpXEnDCwBj/wJ+Ezj8+TlEFjjRWpnFidka+SMdDOXPWSyJv2iNAw=="
     },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "18.1.0",
@@ -1057,9 +1049,9 @@
       "dev": true
     },
     "node_modules/@types/geojson": {
-      "version": "7946.0.7",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.7.tgz",
-      "integrity": "sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==",
+      "version": "7946.0.8",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
+      "integrity": "sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA==",
       "dev": true
     },
     "node_modules/@types/graceful-fs": {
@@ -3458,11 +3450,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-    },
     "node_modules/ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -4674,6 +4661,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/mapbox-vector-tile": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/mapbox-vector-tile/-/mapbox-vector-tile-0.3.0.tgz",
+      "integrity": "sha512-12/08m7pRd/afaVM5Sj07sgHi8R1hg+/vI5SRKkJwVHTFDD/52hSP6QPJpxXtyQzDeox++7hNoAgJ+T/qmmBIQ==",
+      "dependencies": {
+        "@protobuf-ts/runtime": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/md5": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
@@ -5200,18 +5198,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/pbf": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
-      "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
-      "dependencies": {
-        "ieee754": "^1.1.12",
-        "resolve-protobuf-schema": "^2.1.0"
-      },
-      "bin": {
-        "pbf": "bin/pbf"
-      }
-    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -5329,11 +5315,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/protocol-buffers-schema": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.5.1.tgz",
-      "integrity": "sha512-YVCvdhxWNDP8/nJDyXLuM+UFsuPk4+1PB7WGPVDzm3HTHbzFLxQYeW2iZpS4mmnXrQJGBzt230t/BbEb7PrQaw=="
     },
     "node_modules/psl": {
       "version": "1.8.0",
@@ -5642,14 +5623,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/resolve-protobuf-schema": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
-      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
-      "dependencies": {
-        "protocol-buffers-schema": "^3.3.1"
       }
     },
     "node_modules/resolve-url": {
@@ -8134,19 +8107,6 @@
         "chalk": "^4.0.0"
       }
     },
-    "@mapbox/point-geometry": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
-      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI="
-    },
-    "@mapbox/vector-tile": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
-      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
-      "requires": {
-        "@mapbox/point-geometry": "~0.1.0"
-      }
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
@@ -8172,6 +8132,11 @@
         "@nodelib/fs.scandir": "2.1.4",
         "fastq": "^1.6.0"
       }
+    },
+    "@protobuf-ts/runtime": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-1.0.13.tgz",
+      "integrity": "sha512-uvYYBUtG4eCYMxo+mzxN8SHvpL/l7PbHEmOpXEnDCwBj/wJ+Ezj8+TlEFjjRWpnFidka+SMdDOXPWSyJv2iNAw=="
     },
     "@rollup/plugin-commonjs": {
       "version": "18.1.0",
@@ -8312,9 +8277,9 @@
       "dev": true
     },
     "@types/geojson": {
-      "version": "7946.0.7",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.7.tgz",
-      "integrity": "sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==",
+      "version": "7946.0.8",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
+      "integrity": "sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA==",
       "dev": true
     },
     "@types/graceful-fs": {
@@ -10270,11 +10235,6 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
-    "ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -11255,6 +11215,14 @@
         "object-visit": "^1.0.0"
       }
     },
+    "mapbox-vector-tile": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/mapbox-vector-tile/-/mapbox-vector-tile-0.3.0.tgz",
+      "integrity": "sha512-12/08m7pRd/afaVM5Sj07sgHi8R1hg+/vI5SRKkJwVHTFDD/52hSP6QPJpxXtyQzDeox++7hNoAgJ+T/qmmBIQ==",
+      "requires": {
+        "@protobuf-ts/runtime": "^1.0.5"
+      }
+    },
     "md5": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
@@ -11673,15 +11641,6 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
-    "pbf": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
-      "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
-      "requires": {
-        "ieee754": "^1.1.12",
-        "resolve-protobuf-schema": "^2.1.0"
-      }
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -11766,11 +11725,6 @@
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
       }
-    },
-    "protocol-buffers-schema": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.5.1.tgz",
-      "integrity": "sha512-YVCvdhxWNDP8/nJDyXLuM+UFsuPk4+1PB7WGPVDzm3HTHbzFLxQYeW2iZpS4mmnXrQJGBzt230t/BbEb7PrQaw=="
     },
     "psl": {
       "version": "1.8.0",
@@ -12024,14 +11978,6 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
-    },
-    "resolve-protobuf-schema": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
-      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
-      "requires": {
-        "protocol-buffers-schema": "^3.3.1"
-      }
     },
     "resolve-url": {
       "version": "0.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "@types/geojson": "^7946.0.8",
         "@types/jest": "^26.0.20",
         "@types/node": "^14.14.37",
-        "@types/pbf": "^3.0.2",
         "@typescript-eslint/eslint-plugin": "^4.16.1",
         "@typescript-eslint/parser": "^4.16.1",
         "eslint": "^7.21.0",
@@ -1113,12 +1112,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
-      "dev": true
-    },
-    "node_modules/@types/pbf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.2.tgz",
-      "integrity": "sha512-EDrLIPaPXOZqDjrkzxxbX7UlJSeQVgah3i0aA4pOSzmK9zq3BIh7/MZIQxED7slJByvKM4Gc6Hypyu2lJzh3SQ==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -8341,12 +8334,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
-      "dev": true
-    },
-    "@types/pbf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.2.tgz",
-      "integrity": "sha512-EDrLIPaPXOZqDjrkzxxbX7UlJSeQVgah3i0aA4pOSzmK9zq3BIh7/MZIQxED7slJByvKM4Gc6Hypyu2lJzh3SQ==",
       "dev": true
     },
     "@types/prettier": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@rollup/plugin-typescript": "^8.2.1",
     "@tsconfig/node14": "^1.0.0",
     "@types/d3-geo": "^2.0.0",
+    "@types/geojson": "^7946.0.8",
     "@types/jest": "^26.0.20",
     "@types/node": "^14.14.37",
     "@types/pbf": "^3.0.2",
@@ -53,11 +54,10 @@
     }
   },
   "dependencies": {
-    "@mapbox/vector-tile": "^1.3.1",
     "axios": "^0.21.1",
     "axios-cache-adapter": "^2.7.3",
     "d3-geo": "^2.0.1",
     "global-mercator": "^3.1.0",
-    "pbf": "^3.2.1"
+    "mapbox-vector-tile": "^0.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@types/geojson": "^7946.0.8",
     "@types/jest": "^26.0.20",
     "@types/node": "^14.14.37",
-    "@types/pbf": "^3.0.2",
     "@typescript-eslint/eslint-plugin": "^4.16.1",
     "@typescript-eslint/parser": "^4.16.1",
     "eslint": "^7.21.0",

--- a/src/countryOptions.ts
+++ b/src/countryOptions.ts
@@ -1,0 +1,48 @@
+import {
+  ReverseGeocodingOptions,
+  ReverseGeocodingResultCountry,
+  ReverseGeocodingResultJP,
+} from './interfaces'
+
+/**
+ * vector tiles settings for checking country code
+ */
+export const wbCountryOption: ReverseGeocodingOptions = {
+  zoomBase: 6,
+  tileUrl: `https://open-geocoding.github.io/wb-countries/tiles/{z}/{x}/{y}.pbf`,
+  layer: 'wb_countries',
+  getResult: function (feature: GeoJSON.Feature) {
+    const res: ReverseGeocodingResultCountry = {
+      code: feature.properties?.iso_a2,
+      name: feature.properties?.wb_name,
+    }
+    return res
+  },
+}
+
+/**
+ * vector tiles settings for each country
+ */
+const countryOptions: { [s: string]: ReverseGeocodingOptions } = {
+  JP: {
+    zoomBase: 10,
+    tileUrl: `https://open-geocoding.github.io/open-reverse-geocoder-ja/tiles/{z}/{x}/{y}.pbf`,
+    layer: 'japanese-admins',
+    getResult: function (feature: GeoJSON.Feature) {
+      const res: ReverseGeocodingResultJP = {
+        code:
+          5 === String(feature.id).length
+            ? String(feature.id)
+            : `0${String(feature.id)}`,
+        prefecture: feature.properties?.prefecture,
+        city: feature.properties?.city,
+      }
+      return res
+    },
+  },
+}
+
+// default country options
+countryOptions.DEFAULT = countryOptions.JP
+
+export default countryOptions

--- a/src/interfaces/ReverseGeocodingOptions.ts
+++ b/src/interfaces/ReverseGeocodingOptions.ts
@@ -1,0 +1,18 @@
+import { ReverseGeocodingResult } from './ReverseGeocodingResult'
+
+export interface ReverseGeocodingOptions {
+  /** どのズームを使うか。デフォルトは 10 */
+  zoomBase: number
+
+  /** タイルが入ってるURLフォーマット。 */
+  tileUrl: string
+
+  /** 検索するレイヤーのID */
+  layer: string
+
+  /**
+   * リバースジオコーディングの結果を取得するための関数
+   * 国別の定義のところで個別に関数を作成する
+   */
+  getResult: (feature: GeoJSON.Feature) => ReverseGeocodingResult
+}

--- a/src/interfaces/ReverseGeocodingResult.ts
+++ b/src/interfaces/ReverseGeocodingResult.ts
@@ -1,0 +1,21 @@
+/**
+ * Base interface of reverse geocoding result
+ */
+export interface ReverseGeocodingResult {
+  code?: string
+}
+
+/**
+ * Interface of country polygons by world bank
+ */
+export interface ReverseGeocodingResultCountry extends ReverseGeocodingResult {
+  name: string
+}
+
+/**
+ * Interface of reverse geocoding result for Japan
+ */
+export interface ReverseGeocodingResultJP extends ReverseGeocodingResult {
+  prefecture: string
+  city: string
+}

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,0 +1,2 @@
+export * from './ReverseGeocodingOptions'
+export * from './ReverseGeocodingResult'

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -44,3 +44,9 @@ test('八丈町 [139.785231, 33.115122]', async () => {
     city: '八丈町',
   })
 })
+
+test('London [-0.13637, 51.50334]', async () => {
+  await expect(geocoder([-0.13637, 51.50334])).rejects.toThrow(
+    'This service location is not currently available.',
+  )
+})

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,102 +1,30 @@
-import { geoContains } from 'd3-geo'
 import { lngLatToGoogle } from 'global-mercator'
-import Protobuf from 'pbf'
 import axios from 'axios'
 import { setupCache } from 'axios-cache-adapter'
-import { VectorTile } from '@mapbox/vector-tile'
-
-export interface ReverseGeocodingResult {
-  code: string
-  prefecture: string
-  city: string
-}
+import { ReverseGeocodingOptions, ReverseGeocodingResult } from './interfaces'
+import countryOptions from './countryOptions'
+import { getTile, getTileResult, getCountryCode } from './utils'
 
 type LngLat = [number, number]
 
-export interface ReverseGeocodingOptions {
-  /** どのズームを使うか。デフォルトは 10 */
-  zoomBase: number
-
-  /** タイルが入ってるURLフォーマット。 */
-  tileUrl: string
-
-  // 検索するレイヤーのID
-  layer: string
-}
-
-const DEFAULT_OPTIONS: ReverseGeocodingOptions = {
-  zoomBase: 10,
-  tileUrl: `https://open-geocoding.github.io/open-reverse-geocoder-ja/tiles/{z}/{x}/{y}.pbf`,
-  layer: 'japanese-admins'
-}
-
 const cache = setupCache({
-  maxAge: 60 * 60 * 24 * 1000
+  maxAge: 60 * 60 * 24 * 1000,
 })
 
 const api = axios.create({
-  adapter: cache.adapter
+  adapter: cache.adapter,
 })
 
 export const openReverseGeocoder: (
   input: LngLat,
   options?: Partial<ReverseGeocodingOptions>,
-) => Promise<ReverseGeocodingResult> = async (lnglat, inputOptions = {}) => {
-  const options: ReverseGeocodingOptions = {
-    ...DEFAULT_OPTIONS,
-    ...inputOptions,
+) => Promise<ReverseGeocodingResult> = async (lnglat) => {
+  const countryCode = await getCountryCode(lnglat, api)
+  if (!(countryCode.code && countryOptions[countryCode.code])) {
+    throw new Error(`This service location is not currently available.`)
   }
+  const options: ReverseGeocodingOptions = countryOptions[countryCode.code]
   const [x, y] = lngLatToGoogle(lnglat, options.zoomBase)
-  const tileUrl = options.tileUrl
-    .replace('{z}', String(options.zoomBase))
-    .replace('{x}', String(x))
-    .replace('{y}', String(y))
-
-  const geocodingResult = {
-    code: '',
-    prefecture: '',
-    city: '',
-  }
-
-  let buffer
-
-  try {
-    const res = await api.get(tileUrl, { responseType: 'arraybuffer' })
-    buffer =Buffer.from(res.data, 'binary')
-  } catch(error) {
-    throw new Error(error)
-  }
-
-  const tile = new VectorTile(new Protobuf(buffer))
-  let layers = Object.keys(tile.layers)
-
-  if (!Array.isArray(layers)) layers = [layers]
-
-  layers.forEach((layerID) => {
-    const layer = tile.layers[layerID]
-    if (layer && (options.layer === layer.name)) {
-      for (let i = 0; i < layer.length; i++) {
-        const feature = layer.feature(i).toGeoJSON(x, y, options.zoomBase)
-        if (layers.length > 1) feature.properties.vt_layer = layerID
-
-        const geojson = {
-          type: 'FeatureCollection',
-          features: [feature],
-        }
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const res = geoContains(geojson as any, lnglat)
-        if (res) {
-          geocodingResult.code =
-            5 === String(feature.id).length
-              ? String(feature.id)
-              : `0${String(feature.id)}`
-          geocodingResult.prefecture = feature.properties.prefecture
-          geocodingResult.city = feature.properties.city
-        }
-      }
-    }
-  })
-
-  return geocodingResult
+  const tile = await getTile(x, y, options, api)
+  return getTileResult(tile, x, y, lnglat, options)
 }

--- a/src/mapbox_vector_tile.d.ts
+++ b/src/mapbox_vector_tile.d.ts
@@ -1,1 +1,0 @@
-declare module '@mapbox/vector-tile'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,100 @@
+import { geoContains } from 'd3-geo'
+import { lngLatToGoogle } from 'global-mercator'
+import axios, { AxiosInstance } from 'axios'
+import { VectorTile } from 'mapbox-vector-tile'
+import { ReverseGeocodingOptions, ReverseGeocodingResult } from './interfaces'
+import { wbCountryOption } from './countryOptions'
+
+/**
+ * Get a tile from targeted country's tilesets by using x and y tile index
+ * @param x x tile index
+ * @param y y tile index
+ * @param options ReverseGeocodingOptions
+ * @param api Axios object
+ * @returns VectorTile object
+ */
+export const getTile = async (
+  x: number,
+  y: number,
+  options: ReverseGeocodingOptions,
+  api: AxiosInstance = axios,
+): Promise<VectorTile> => {
+  const tileUrl = options.tileUrl
+    .replace('{z}', String(options.zoomBase))
+    .replace('{x}', String(x))
+    .replace('{y}', String(y))
+
+  let buffer
+
+  try {
+    const res = await api.get(tileUrl, { responseType: 'arraybuffer' })
+    buffer = Buffer.from(res.data, 'binary')
+  } catch (error) {
+    throw error
+  }
+
+  const tile = new VectorTile(buffer)
+  return tile
+}
+
+/**
+ * Get a result of reverse geocoding
+ * @param tile VectorTile object
+ * @param x x tile index
+ * @param y y tile index
+ * @param lnglat number[] longitude, latitude
+ * @param options ReverseGeocodingOptions
+ * @returns an object of result of reverse gecoding
+ */
+export const getTileResult = (
+  tile: VectorTile,
+  x: number,
+  y: number,
+  lnglat: [number, number],
+  options: ReverseGeocodingOptions,
+): ReverseGeocodingResult => {
+  let layers = Object.keys(tile.layers)
+
+  if (!Array.isArray(layers)) layers = [layers]
+
+  let geocodingResult: ReverseGeocodingResult = {}
+  layers.forEach((layerID) => {
+    const layer = tile.layers[layerID]
+    if (layer && options.layer === layer.name) {
+      for (let i = 0; i < layer.length; i++) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const feature: any = layer.feature(i).toGeoJSON(x, y, options.zoomBase)
+        if (layers.length > 1) feature.properties.vt_layer = layerID
+
+        const geojson = {
+          type: 'FeatureCollection',
+          features: [feature],
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const res = geoContains(geojson as any, lnglat)
+        if (res) {
+          geocodingResult = options.getResult(feature)
+        }
+      }
+    }
+  })
+  return geocodingResult
+}
+
+/**
+ * Get country information intersects with specified longitude and latitude
+ * @param lnglat number[] longtitude, latitude
+ * @param api Axios object
+ * @returns Country Object eg. { code: 'JP', name: 'Japan'}
+ */
+export const getCountryCode = async (
+  lnglat: [number, number],
+  api: AxiosInstance = axios,
+): Promise<ReverseGeocodingResult> => {
+  const options = wbCountryOption
+  const [x, y] = lngLatToGoogle(lnglat, options.zoomBase)
+
+  const tile = await getTile(x, y, options, api)
+  return getTileResult(tile, x, y, lnglat, options)
+}


### PR DESCRIPTION
@miya0001 
- 世界銀行の国ポリゴンタイルを見に行くために、処理を共通化しました。
- 国別にタイル情報を定義できるようにしました。
- テストケースに対象外の国の緯度軽度の時のケースを追加しました。