### PR TITLE
GitHub Actions workflowのリファクタリング

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -1,23 +1,16 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: build
+name: Lint and Test
 
-on:
-  push:
-    branches: ['*']
-    tags: ['*']
-  pull_request:
-    branches: [master]
+on: push
 
 jobs:
-  build:
+  lint_and_test:
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: [14.x, 16.x]
-
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
@@ -30,23 +23,3 @@ jobs:
       - run: npm test
       # allow fails
       # - run: npm run test:addresses || true
-
-  publish:
-    name: 'Publish npm package'
-    runs-on: ubuntu-latest
-    needs: build
-    if: startsWith(github.ref, 'refs/tags/v')
-    steps:
-      - uses: actions/checkout@v2
-      # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v1
-        with:
-          tag_name: 'v%s'
-          node-version: '14.x'
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@geolonia'
-      - run: npm install
-      - run: npm run build
-      - run: npm publish --access=public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
       - run: npm ci
       - run: npm run build
       - run: npm run lint

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -13,8 +13,6 @@ jobs:
   publish_npm:
     name: 'Publish npm package'
     runs-on: ubuntu-latest
-    needs: build
-    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v2
       # Setup .npmrc file to publish to npm

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -1,0 +1,31 @@
+# This workflow only run if Lint and Test workflow has passed.
+# For more information see: https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#workflow_run
+
+name: Publish npm package
+
+on:
+  workflow_run:
+    workflows: ["Lint and Test"]
+    types: [completed]
+    tags: ['*']
+
+jobs:
+  publish_npm:
+    name: 'Publish npm package'
+    runs-on: ubuntu-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v2
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v1
+        with:
+          tag_name: 'v%s'
+          node-version: '14.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@geolonia'
+      - run: npm install
+      - run: npm run build
+      - run: npm publish --access=public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -20,8 +20,9 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v1
         with:
-          tag_name: 'v%s'
           node-version: '14.x'
+          cache: npm
+          tag_name: 'v%s'
           registry-url: 'https://registry.npmjs.org'
           scope: '@geolonia'
       - run: npm install


### PR DESCRIPTION
## What do this pull request

- `.github/workflows/build.yml` を `lint_and_test.yml` と `publish_npm.yml` に分割します


## Why do this pull request

- LintやTestはPushされたら常に実行されるべき
- npmにPublishするのはtagsがPushされて、かつ、LintやTestが成功した時のみであるべき
- という考えに基づいて、 `build.yml` を分割しました
- `on: workflow_run` という構文でWorkflowをまたいだ依存関係の指定ができるので、Tagが作られて、かつ、Lint and Testが成功した場合にのみPublish npm packageを実行します


## Impact range for user

- Nothing.

